### PR TITLE
predictMaxNet error

### DIFF
--- a/R/predictMaxNet.r
+++ b/R/predictMaxNet.r
@@ -27,9 +27,9 @@ predictMaxNet <- function(object, newdata, clamp=TRUE, type='cloglog', ...)
 {
 	
 	if (inherits(newdata, 'Raster')) {
-		out <- raster::predict(clim, object, fun=predictMaxNet, ...)
+		out <- raster::predict(newdata, object, fun=predictMaxNet, ...)
 	} else if (inherits(newdata, 'SpatRaster')) {
-		out <- terra::predict(clim, object, fun=predictMaxNet, ...)
+		out <- terra::predict(newdata, object, fun=predictMaxNet, ...)
 	} else {
 
 		if (clamp) {


### PR DESCRIPTION
I received an error from predictMaxNet: "error in evaluating the argument 'object' in selecting a method for function 'predict': object 'clim' not found". I updated 'clim' to 'newdata' in the code, which seemed to fix the problem.

Thanks,
Lydia